### PR TITLE
fix Client CI version check exception

### DIFF
--- a/src/main/java/com/baidu/hugegraph/driver/HugeClient.java
+++ b/src/main/java/com/baidu/hugegraph/driver/HugeClient.java
@@ -142,7 +142,7 @@ public class HugeClient implements Closeable {
     private void checkServerApiVersion() {
         VersionUtil.Version apiVersion = VersionUtil.Version.of(
                                          this.version.getApiVersion());
-        VersionUtil.check(apiVersion, "0.38", "0.69",
+        VersionUtil.check(apiVersion, "0.38", "0.70",
                           "hugegraph-api in server");
         this.client.apiVersion(apiVersion);
     }


### PR DESCRIPTION
modify the check of hugegraph server api version, change upper limit from 0.69  to 0.70 in HugeClient class.